### PR TITLE
Crash early methods now regulated via settable flag

### DIFF
--- a/DaylightUtils/Error/ErrorReporting.swift
+++ b/DaylightUtils/Error/ErrorReporting.swift
@@ -26,31 +26,31 @@ public func fatalErrorInDebugOrReportError<T>(default: T, file: String = #file, 
     do {
         return try action()
     } catch let error {
-        #if DEBUG
-        fatalError("Error while executing: \(error)")
-        #else
-        reportError(error, file: file, function: function, line: line)
-        return `default`
-        #endif
+        if Debug.isEnabled {
+            fatalError("Error while executing: \(error)")
+        } else {
+            reportError(error, file: file, function: function, line: line)
+            return `default`
+        }
     }
 }
 
 public func fatalErrorInDebugOrReportError(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-    #if DEBUG
-    print("\(file):\(line)")
-    fatalError(message)
-    #else
-    reportError(message, file: file, function: function, line: line)
-    #endif
+    if Debug.isEnabled {
+        print("\(file):\(line)")
+        fatalError(message)
+    } else {
+        reportError(message, file: file, function: function, line: line)
+    }
 }
 
 public func fatalErrorInDebugOrReportError(_ error: Error, file: String = #file, function: String = #function, line: Int = #line) {
-    #if DEBUG
-    print("\(file):\(line)")
-    fatalError(error.localizedDescription)
-    #else
-    reportError(error, file: file, function: function, line: line)
-    #endif
+    if Debug.isEnabled {
+        print("\(file):\(line)")
+        fatalError(error.localizedDescription)
+    } else {
+        reportError(error, file: file, function: function, line: line)
+    }
 }
 
 public func reportError(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {

--- a/DaylightUtils/Extensions/Observable+Extensions.swift
+++ b/DaylightUtils/Extensions/Observable+Extensions.swift
@@ -14,22 +14,22 @@ extension ObservableType {
     public func asDriverIgnoringErrors(file: String = #file, function: String = #function, line: Int = #line) -> Driver<E> {
         return asDriver(onErrorRecover: { e in
             reportError(e, file: file, function: function, line: line)
-            #if DEBUG
-            fatalError("\(e)")
-            #else
-            return Driver.empty()
-            #endif
+            if Debug.isEnabled {
+                fatalError("\(e)")
+            } else {
+                return Driver.empty()
+            }
         })
     }
     
     public func asSignalIgnoringErrors(file: String = #file, function: String = #function, line: Int = #line) -> Signal<E> {
         return asSignal(onErrorRecover: { e in
             reportError(e, file: file, function: function, line: line)
-            #if DEBUG
-            fatalError("\(e)")
-            #else
-            return Signal.empty()
-            #endif
+            if Debug.isEnabled {
+                fatalError("\(e)")
+            } else {
+                return Signal.empty()
+            }
         })
     }
     
@@ -100,22 +100,22 @@ extension PrimitiveSequence {
     public func asDriverIgnoringErrors(file: String = #file, function: String = #function, line: Int = #line) -> Driver<E> {
         return asDriver(onErrorRecover: { e in
             reportError(e, file: file, function: function, line: line)
-            #if DEBUG
-            fatalError("\(e)")
-            #else
-            return Driver.empty()
-            #endif
+            if Debug.isEnabled {
+                fatalError("\(e)")
+            } else {
+                return Driver.empty()
+            }
         })
     }
     
     public func asSignalIgnoringErrors(file: String = #file, function: String = #function, line: Int = #line) -> Signal<E> {
         return asSignal(onErrorRecover: { e in
             reportError(e, file: file, function: function, line: line)
-            #if DEBUG
-            fatalError("\(e)")
-            #else
-            return Signal.empty()
-            #endif
+            if Debug.isEnabled {
+                fatalError("\(e)")
+            } else {
+                return Signal.empty()
+            }
         })
     }
 }

--- a/DaylightUtils/Logging/Logger.swift
+++ b/DaylightUtils/Logging/Logger.swift
@@ -9,36 +9,34 @@
 import Foundation
 
 public struct Debug {
+    #if DEBUG
+    public static var isEnabled = true
+    #else
+    public static var isEnabled = false
+    #endif
+    
     public static var isLoggingEnabled = false
     
     public static func log(_ error: Error) {
-        #if DEBUG
-        debugPrint(error)
-        #else
-        if isLoggingEnabled {
+        if Debug.isEnabled || Debug.isLoggingEnabled {
             debugPrint(error)
         }
-        #endif
     }
     
     public static func log(_ item: @autoclosure () -> Any) {
-        #if DEBUG
-        debugPrint("\(item())".utils.trimmedForLogging())
-        #else
-        if isLoggingEnabled {
+        if Debug.isEnabled || Debug.isLoggingEnabled {
             debugPrint("\(item())".utils.trimmedForLogging())
         }
-        #endif
     }
     
     public static func crashlyticsLog(_ message: String = "", file: String = #file, function: String = #function, line: Int = #line) {
         let filename = URL(string: file)?.lastPathComponent ?? ""
         let prefix = "\(filename):\(line).\(function)"
         
-        #if DEBUG
-        crashlyticsInstance?.CLSNSLogv("\(prefix): \(message)")
-        #else
-        crashlyticsInstance?.CLSLogv("\(prefix): \(message)")
-        #endif
+        if Debug.isEnabled {
+            crashlyticsInstance?.CLSNSLogv("\(prefix): \(message)")
+        } else {
+            crashlyticsInstance?.CLSLogv("\(prefix): \(message)")
+        }
     }
 }


### PR DESCRIPTION
Error reporting and debugging methods switched to check a settable `Debug.isEnabled` flag instead of using the DEBUG compilation flag. This enables smoother integration of the framework - one does not need to build the Debug configuration for local work and a Release configuration for distribution.